### PR TITLE
WIP begin async processing of scanned documents

### DIFF
--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -160,6 +160,8 @@ type GitScanConfig struct {
 	// or "<user>/<repo>". Values in this list take precedence over values in
 	// the Repositories list.
 	IgnoreRepositories []string `yaml:"ignore_repositories" json:"ignore_repositories"`
+	// Limits config
+	Limits GitScanLimitsConfig `yaml:"limits" json:"limits"`
 	// Organization is the URL of the GitHub organization to scan, where the
 	// app will query the GitHub API for a list of repositories to scan.
 	Organization string `yaml:"organization" json:"organization"`
@@ -171,6 +173,10 @@ type GitScanConfig struct {
 	// listed in Repositories, minus any duplicates and minus any repositories
 	// listed in the IgnoreRepositories list.
 	Repositories []string `yaml:"repositories" json:"repositories"`
+}
+
+type GitScanLimitsConfig struct {
+	MaxRequestsOutstanding int `yaml:"max_requests_outstanding" json:"max_requests_outstanding"`
 }
 
 // ServerConfig struct contains the configuration used to start the HTTP server.
@@ -212,6 +218,9 @@ func (c *Config) defaultConfig() {
 	c.AzureAI.ShowStats = DefaultAzureAIShowStats
 	if c.Command.Run == "" {
 		c.Command.Run = DefaultCommandRun
+	}
+	if c.Git.Scan.Limits.MaxRequestsOutstanding == 0 {
+		c.Git.Scan.Limits.MaxRequestsOutstanding = DefaultMaxRequestsOutstanding
 	}
 	if c.Git.WorkDir == "" {
 		c.Git.WorkDir = DefaultCommandWorkDir

--- a/pkg/cfg/constants.go
+++ b/pkg/cfg/constants.go
@@ -22,6 +22,7 @@ const DefaultCommandRun string = CommandRunHelp
 const DefaultCommandWorkDir string = "/tmp/" + DefaultAppName
 const DefaultConfidenceThreshold float64 = 0.6
 const DefaultGitHubV3APIURL string = "https://api.github.com"
+const DefaultMaxRequestsOutstanding int = 100
 const DefaultRateLimit float64 = 1000.0
 const DefaultServerAddress string = "127.0.0.1"
 const DefaultServerPort int = 8080

--- a/pkg/cfg/env.go
+++ b/pkg/cfg/env.go
@@ -19,6 +19,7 @@ const NOPHI_GH_V3APIURL string = "NOPHI_GH_V3APIURL"
 const NOPHI_GH_V4APIURL string = "NOPHI_GH_V4APIURL"
 const NOPHI_GH_WEBHOOK_SECRET = "NOPHI_GH_WEBHOOK_SECRET"
 const NOPHI_GIT_WORKDIR = "NOPHI_GIT_WORKDIR"
+const NOPHI_MAX_REQUESTS_OUTSTANDING = "NOPHI_MAX_REQUESTS_OUTSTANDING"
 const NOPHI_SERVER_ADDRESS string = "NOPHI_SERVER_ADDRESS"
 const NOPHI_SERVER_PORT string = "NOPHI_SERVER_PORT"
 
@@ -37,6 +38,7 @@ func GetAppEnvVars() []string {
 		NOPHI_GH_V4APIURL,
 		NOPHI_GH_WEBHOOK_SECRET,
 		NOPHI_GIT_WORKDIR,
+		NOPHI_MAX_REQUESTS_OUTSTANDING,
 		NOPHI_SERVER_ADDRESS,
 		NOPHI_SERVER_PORT,
 	}
@@ -62,6 +64,12 @@ func (c *Config) envOverride() error {
 	}
 	if commandRun := os.Getenv(NOPHI_COMMAND_RUN); commandRun != "" {
 		c.Command.Run = commandRun
+	}
+	if maxRequestsOutstanding := os.Getenv(NOPHI_MAX_REQUESTS_OUTSTANDING); maxRequestsOutstanding != "" {
+		maxRequestsOutstandingInt, err := strconv.Atoi(maxRequestsOutstanding)
+		if err == nil {
+			c.Git.Scan.Limits.MaxRequestsOutstanding = maxRequestsOutstandingInt
+		}
 	}
 	if gitWorkDir := os.Getenv(NOPHI_GIT_WORKDIR); gitWorkDir != "" {
 		c.Git.WorkDir = gitWorkDir

--- a/pkg/client/az/constants.go
+++ b/pkg/client/az/constants.go
@@ -2,7 +2,8 @@ package az
 
 const DefaultDetectionApi string = "language/:analyze-text?api-version=2022-05-01"
 const DefaultLanguage string = "en"
-
+const DocumentCharacterLimit int = 5000
+const RequestDocumentLimit int = 5
 const ShowStatsParam string = "&showStats=true"
 
 func GetDefaultDetectionApi(showStats bool) string {

--- a/pkg/scanner/constants.go
+++ b/pkg/scanner/constants.go
@@ -1,6 +1,8 @@
 package scanner
 
-const ScanObjectTypeCommit = "commit"
-const ScanObjectTypeFile = "file"
-const ScanObjectTypeOrganization = "organization"
-const ScanObjectTypeRepository = "repository"
+const DelimitDocumentID string = "__"
+
+const ScanObjectTypeCommit string = "commit"
+const ScanObjectTypeFile string = "file"
+const ScanObjectTypeOrganization string = "organization"
+const ScanObjectTypeRepository string = "repository"

--- a/pkg/scanner/errors.go
+++ b/pkg/scanner/errors.go
@@ -5,6 +5,7 @@ import "github.com/pkg/errors"
 var (
 	ErrDocumentResponseIsNil            = errors.New("DocumentResponse is nil")
 	ErrDocumentResponseMismatch         = errors.New("DocumentResponse mismatch")
+	ErrDocumentTrackerMapInputIsNil     = errors.New("DocumentTracker map input is nil")
 	ErrScanCommitFilesNotSet            = errors.New("ScanCommit files not set")
 	ErrScanCommitScanFileNotFound       = errors.New("ScanFile not found in ScanCommit")
 	ErrScanFileInputNil                 = errors.New("ScanFile input is nil")

--- a/pkg/scanner/id.go
+++ b/pkg/scanner/id.go
@@ -1,0 +1,27 @@
+package scanner
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"strconv"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func MakeDocumentID(hash plumbing.Hash, offset int, text_bytes []byte) (id string) {
+	string_to_hash := strings.Join(
+		[]string{
+			hash.String(),
+			strconv.Itoa(offset),
+			string(text_bytes),
+		},
+		DelimitDocumentID,
+	)
+
+	hasher := sha1.New()
+	hasher.Write([]byte(string_to_hash))
+	id = base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+	return
+}

--- a/pkg/scanner/scan_file.go
+++ b/pkg/scanner/scan_file.go
@@ -1,9 +1,13 @@
 package scanner
 
 import (
+	"bufio"
 	"fmt"
 
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/pkg/errors"
+
+	"github.com/has-ghas/no-phi-ai/pkg/client/az"
 )
 
 // ScanFile struct embeds the ScanObject struct and adds fields
@@ -15,46 +19,142 @@ type ScanFile struct {
 
 // NewScanFile() function initializes a new ScanFile object using
 // the provided URL for the GitHub organization.
-func NewScanFile(file *object.File) (*ScanFile, error) {
+func NewScanFile(
+	file *object.File,
+	channel_documents chan<- az.AsyncDocumentWrapper,
+	channel_quit <-chan error,
+) (*ScanFile, error) {
 	if file == nil {
 		return nil, ErrScanFileInputNil
 	}
 	// initialize and return a new ScanFile object
 	return &ScanFile{
-		ScanObjectHashed: *NewScanObjectHashed(
-			file.ID(),
-			file.Name,
-			ScanObjectTypeFile,
-			"", // TODO
-		),
+		ScanObjectHashed: *NewScanObjectHashed(file.ID(), &ScanObjectInput{
+			ChannelDocuments: channel_documents,
+			ChannelQuit:      channel_quit,
+			ID:               file.ID().String(),
+			Name:             file.Name,
+			ObjectType:       ScanObjectTypeFile,
+			URL:              "", // TODO
+		}),
 	}, nil
+}
+
+// Scan() method wraps the private methods that implement the scanning
+// the text of the file (blob) for PHI/PII entities. The method is
+// expected to return an error if the scan fails to run for that file.
+func (sf *ScanFile) Scan(file *object.File) (e error) {
+
+	// generate a new DocumentTracker for each chunk of the file, where
+	// the chunk size is determined by the az.DocumentCharacterLimit
+	if e = sf.generateDocuments(file); e != nil {
+		return
+	}
+
+	// batch the documents into groups of az.RequestDocumentLimit
+	// and create a new az.PiiEntityRecognitionRequest for each batch
+	// TODO
+
+	// submit the requests to the Azure AI Language service API
+	// TODO
+
+	// process the responses from the Azure AI Language service API
+	// TODO
+
+	return
 }
 
 // generateDocuments() function generates PHI/PII entity detection
 // requests from the provided object.File, which is a file or blob in a
 // git repository. Requests are limited to a maximum of 5 "documents",
-// with a limit of 5,000 characters per "document".
+// obeying the az.DocumentCharacterLimit per "document".
 func (sf *ScanFile) generateDocuments(file *object.File) (e error) {
-	documents := NewDocumentTrackerMap()
 
-	// TODO : remove TRACE
-	fmt.Println("TRACE : ScanFile.generateDocuments() : start")
+	file_reader, err := file.Reader()
+	if err != nil {
+		e = errors.Wrap(err, "failed to get file reader for generating documents")
+		return
+	}
+	file_scanner := bufio.NewScanner(file_reader)
+	file_scanner.Split(bufio.ScanRunes)
+	var current_offset int
+	var current_text string
+	// scan the file / blob and split into chunks and prepare to scan each
+	// chunk for PHI by creating a new DocumentTracker object that allows
+	// for mapping any documents to their respective offsets in the file
+	for file_scanner.Scan() {
+		char := file_scanner.Text()
+		current_text += char
 
-	// split the file / blob into chunks and prepare to scan each chunk
-	// for PHI by creating a new DocumentTracker object for each chunk of
-	// the file
-	// TODO
+		if len(current_text) == az.DocumentCharacterLimit {
+			if e = sf.makeDocumentTracker(current_offset, current_text); e != nil {
+				return
+			}
+			// reset the current_text variable to prepare for the next
+			// chunk of the file
+			current_text = ""
+			// increment the current_offset variable to the next character
+			current_offset += len(char)
+		}
+	}
 
-	// set the documents field of the ScanFile object to the generated
-	// map of DocumentTracker objects
-	if documents.CountTotal() > 0 {
-		if e = sf.SetDocuments(documents); e != nil {
+	// handle the last chunk of characters from the file
+	if len(current_text) > 0 {
+		e = sf.makeDocumentTracker(current_offset, current_text)
+		if e != nil {
 			return
 		}
 	}
 
-	// TODO : remove TRACE
-	fmt.Println("TRACE : ScanFile.generateDocuments() : finish")
+	// check the file_scanner for any error
+	if err := file_scanner.Err(); err != nil {
+		e = errors.Wrap(err, "file scanner returned error when generating documents")
+		return
+	}
 
 	return
+}
+
+// makeDocumentTracker() method uses the context of the ScanFile object
+// along with the provided offset and text to create a new DocumentTracker
+// for the text.
+func (sf *ScanFile) makeDocumentTracker(offset int, text string) error {
+	// create a unique identifier for the document
+	id := MakeDocumentID(sf.GetHash(), offset, []byte(text))
+
+	// TODO : remove TRACE
+	fmt.Printf(
+		"TRACE : ScanFile.makeDocumentTracker() : hash=%s : path=%s : id=%s : offset=%d : text_length=%d\n",
+		sf.hash.String(),
+		sf.Name,
+		id,
+		offset,
+		len(text),
+	)
+
+	// create the az.Document object which is a required input for a new DocumentTracker
+	az_doc := az.NewDocument(id, text, "")
+
+	document_tracker, err := NewDocumentTracker(&DocumentTrackerInput{
+		ChannelDocuments: sf.channelDocuments,
+		ChannelQuit:      sf.channelQuit,
+		Document:         &az_doc,
+		ID:               az_doc.ID,
+		Offset:           offset,
+		Path:             sf.Name,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to setup DocumentTracker for scan file")
+	}
+
+	// add the document_tracker object to the map of documents
+	// stored in the ScanFile object
+	if err := sf.documents.Set(document_tracker); err != nil {
+		return err
+	}
+
+	// use the document tracker to wrap and send the document to be scanned
+	go document_tracker.Scan()
+
+	return nil
 }

--- a/pkg/scanner/scan_organization.go
+++ b/pkg/scanner/scan_organization.go
@@ -1,6 +1,9 @@
 package scanner
 
-import nogit "github.com/has-ghas/no-phi-ai/pkg/client/no-git"
+import (
+	"github.com/has-ghas/no-phi-ai/pkg/client/az"
+	nogit "github.com/has-ghas/no-phi-ai/pkg/client/no-git"
+)
 
 // ScanOrganization struct embeds the ScanObject struct and adds fields
 // and methods specific to scanning a GitHub organization.
@@ -11,7 +14,11 @@ type ScanOrganization struct {
 
 // NewScanOrganization() function initializes a new ScanOrganization object using
 // the provided URL for the GitHub organization.
-func NewScanOrganization(org_url string) (*ScanOrganization, error) {
+func NewScanOrganization(
+	org_url string,
+	channel_documents chan<- az.AsyncDocumentWrapper,
+	channel_quit <-chan error,
+) (*ScanOrganization, error) {
 	// parse the name of the organization from the provided URL
 	org_name, err := nogit.ParseOrgNameFromURL(org_url)
 	if err != nil {
@@ -19,11 +26,13 @@ func NewScanOrganization(org_url string) (*ScanOrganization, error) {
 	}
 	// initialize and return a new ScanOrganization object
 	return &ScanOrganization{
-		ScanObject: *NewScanObject(
-			org_url,
-			org_name,
-			ScanObjectTypeOrganization,
-			org_url,
-		),
+		ScanObject: *NewScanObject(&ScanObjectInput{
+			ChannelDocuments: channel_documents,
+			ChannelQuit:      channel_quit,
+			ID:               org_url,
+			Name:             org_name,
+			ObjectType:       ScanObjectTypeOrganization,
+			URL:              org_url,
+		}),
 	}, nil
 }


### PR DESCRIPTION
Creats a new DocumentTracker type for sending documents through a common (go) channel for async processing. Uses goroutines and wait-groups to allow for background processing of documents from a fixed length queue (i.e. a channel that allows for storing a limited number of documents to be processed).